### PR TITLE
Add status bar icon toggle

### DIFF
--- a/Lemon/Preference/LMPreferenceStatusBarViewController.m
+++ b/Lemon/Preference/LMPreferenceStatusBarViewController.m
@@ -7,6 +7,7 @@
 //
 
 #import "LMPreferenceStatusBarViewController.h"
+#import "LemonDaemonConst.h"
 #import <QMUICommon/LMAppThemeHelper.h>
 #import <QMUICommon/COSwitch.h>
 #import <QMCoreFunction/LanguageHelper.h>
@@ -66,41 +67,17 @@
     [LMAppThemeHelper setDivideLineColorFor:_bootMonitorLineView];
 }
 -(void)initView {
-    NSTextField *showStatusBarIconText = [self buildLabel:NSLocalizedStringFromTableInBundle(@"PreferenceViewController_toggleStatusBarVisibility", nil, [NSBundle bundleForClass:[self class]], @"Toggle status bar visibility") font:[NSFont systemFontOfSize:14] color:[LMAppThemeHelper getTitleColor]];
-    
-    __weak typeof(self) weakSelf = self;
-    // 状态栏显示设置
-    COSwitch *statusBarVisibilitySwitch = [[COSwitch alloc] init];
-    statusBarVisibilitySwitch.on = (_myStatusType & STATUS_TYPE_GLOBAL) > 0 ? YES : NO;
-    [statusBarVisibilitySwitch setOnValueChanged:^(COSwitch *button) {
-        dispatch_async(dispatch_get_main_queue(), ^{
-            button.isEnable = NO;
-            NSLog(@"statusBarVisibilitySwitch setOnValueChanged: %d", button.on);
-            
-            if (button.on) {
-                NSLog(@"preference:global=%d", button.on);
-                
-                weakSelf.myStatusType |= STATUS_TYPE_GLOBAL;
-                [[NSUserDefaults standardUserDefaults] setObject:[NSNumber numberWithInteger:weakSelf.myStatusType] forKey:kLemonShowMonitorCfg];
-            } else {
-                NSLog(@"preference:global=%d", button.on);
-
-                weakSelf.myStatusType &= ~STATUS_TYPE_GLOBAL;
-                [[NSUserDefaults standardUserDefaults] setObject:[NSNumber numberWithInteger:weakSelf.myStatusType] forKey:kLemonShowMonitorCfg];
-            }
-            
-            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
-                button.isEnable = YES;
-            });
-        });
-    }];
     
     NSTextField *showStatusBarIconOnBootText = [self buildLabel:NSLocalizedStringFromTableInBundle(@"PreferenceViewController_setupViews_bootMonitorTitle _16", nil, [NSBundle bundleForClass:[self class]], @"") font:[NSFont systemFontOfSize:14] color:[LMAppThemeHelper getTitleColor]];
     
     // 状态栏开机启动项设置
     _myStatusType = [[[NSUserDefaults standardUserDefaults] objectForKey:kLemonShowMonitorCfg] integerValue];
+    __weak typeof(self) weakSelf = self;
     COSwitch *bootMonitorSwitch = [[COSwitch alloc] init];
     bootMonitorSwitch.on = (_myStatusType & STATUS_TYPE_BOOTSHOW) > 0 ? YES : NO;
+    bootMonitorSwitch.wantsLayer = YES;
+    bootMonitorSwitch.isEnable = (_myStatusType & STATUS_TYPE_GLOBAL) > 0 ? YES : NO;
+    bootMonitorSwitch.layer.opacity = (_myStatusType & STATUS_TYPE_GLOBAL) > 0 ? 1 : 0.5;
     [bootMonitorSwitch setOnValueChanged:^(COSwitch *button) {
         dispatch_async(dispatch_get_main_queue(), ^{
             button.isEnable = NO;
@@ -123,9 +100,51 @@
         });
     }];
     
+    
+    NSTextField *showStatusBarIconText = [self buildLabel:NSLocalizedStringFromTableInBundle(@"PreferenceViewController_toggleStatusBarVisibility", nil, [NSBundle bundleForClass:[self class]], @"Toggle status bar visibility") font:[NSFont systemFontOfSize:14] color:[LMAppThemeHelper getTitleColor]];
+    
+    // 状态栏显示设置
+    COSwitch *statusBarVisibilitySwitch = [[COSwitch alloc] init];
+    statusBarVisibilitySwitch.on = (_myStatusType & STATUS_TYPE_GLOBAL) > 0 ? YES : NO;
+    [statusBarVisibilitySwitch setOnValueChanged:^(COSwitch *button) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            button.isEnable = NO;
+            NSLog(@"statusBarVisibilitySwitch setOnValueChanged: %d", button.on);
+            
+            if (button.on) {
+                NSLog(@"preference:global=%d", button.on);
+                
+                weakSelf.myStatusType |= STATUS_TYPE_GLOBAL;
+                [[NSUserDefaults standardUserDefaults] setObject:[NSNumber numberWithInteger:weakSelf.myStatusType] forKey:kLemonShowMonitorCfg];
+                
+                [self openMonitor];
+                
+                bootMonitorSwitch.isEnable = YES;
+                bootMonitorSwitch.layer.opacity = 1.0;
+            } else {
+                NSLog(@"preference:global=%d", button.on);
+                
+                weakSelf.myStatusType &= ~STATUS_TYPE_GLOBAL;
+                [[NSUserDefaults standardUserDefaults] setObject:[NSNumber numberWithInteger:weakSelf.myStatusType] forKey:kLemonShowMonitorCfg];
+                
+                // 去掉开机启动，并且设置为不可修改
+                bootMonitorSwitch.on = NO;
+                bootMonitorSwitch.isEnable = NO;
+                bootMonitorSwitch.layer.opacity = 0.5;
+            }
+            
+            // send to monitor process
+            NSDictionary* dict = @{@"type":[NSNumber numberWithInteger: [weakSelf myStatusType]]};
+            [[NSDistributedNotificationCenter defaultCenter] postNotificationName:kStatusChangedNotification object:nil userInfo:dict deliverImmediately:YES];
+            
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+                button.isEnable = YES;
+            });
+        });
+    }];
+    
     NSView* bootMonitorLineView = [[NSView alloc] init];
     self.bootMonitorLineView = bootMonitorLineView;
-    
     
     // 状态栏图标显示
     NSTextField *tfMonitorTitle = [self buildLabel:NSLocalizedStringFromTableInBundle(@"PreferenceViewController_setupViews_tfMonitorTitle _9", nil, [NSBundle bundleForClass:[self class]], @"") font:[NSFont systemFontOfSize:14] color:[LMAppThemeHelper getTitleColor]];
@@ -296,6 +315,16 @@
     // 第一次，统一改变状态
     [[NSNotificationCenter defaultCenter] postNotificationName:kLemonStatusOptionsChanged object:[[NSNumber alloc] initWithInteger:_myStatusType]];
     
+}
+
+-(void)openMonitor{
+    NSLog(@"%s, open monitor", __FUNCTION__);
+    NSError *error = NULL;
+    NSRunningApplication *app = [[NSWorkspace sharedWorkspace] launchApplicationAtURL:[NSURL fileURLWithPath:MONITOR_APP_PATH]
+                                                                              options:NSWorkspaceLaunchWithoutAddingToRecents | NSWorkspaceLaunchWithoutActivation
+                                                                        configuration:@{NSWorkspaceLaunchConfigurationArguments: @[[NSString stringWithFormat:@"%lu", LemonMonitorRunningMenu]]}
+                                                                                error:&error];
+    NSLog(@"%s, open lemon monitor: %@, %@",__FUNCTION__, app, error);
 }
 
 -(NSView*)getOptionView:(NSString*)image :(NSString*)tittle :(NSInteger)type

--- a/Lemon/Resources/Base.lproj/Localizable.strings
+++ b/Lemon/Resources/Base.lproj/Localizable.strings
@@ -25,7 +25,7 @@
 "PreferenceViewController_setupViews_1553049563_13" = "CPU\n temperature";
 "PreferenceViewController_setupViews_1553049563_14" = "Fan\n speed";
 "PreferenceViewController_setupViews_1553049563_15" = "Network\n speed";
-"PreferenceViewController_setupViews_bootMonitorTitle _16" = "Show icons on menu bar on startup";
+"PreferenceViewController_setupViews_bootMonitorTitle _16" = "Show on startup";
 "PreferenceViewController_toggleStatusBarVisibility" = "Show status bar icons";
 "About_windowAboutTitle_lemon" = "About Lemon Cleaner";
 "Appdelegate_about_windowAboutTitle_lemonlite" = "About Lemon Cleaner";

--- a/Lemon/Resources/Base.lproj/Localizable.strings
+++ b/Lemon/Resources/Base.lproj/Localizable.strings
@@ -26,6 +26,7 @@
 "PreferenceViewController_setupViews_1553049563_14" = "Fan\n speed";
 "PreferenceViewController_setupViews_1553049563_15" = "Network\n speed";
 "PreferenceViewController_setupViews_bootMonitorTitle _16" = "Show icons on menu bar on startup";
+"PreferenceViewController_toggleStatusBarVisibility" = "Show status bar icons";
 "About_windowAboutTitle_lemon" = "About Lemon Cleaner";
 "Appdelegate_about_windowAboutTitle_lemonlite" = "About Lemon Cleaner";
 "AppDelegate_fetchResearchChannel_notification_1" = "Close";

--- a/Lemon/Resources/en.lproj/Localizable.strings
+++ b/Lemon/Resources/en.lproj/Localizable.strings
@@ -28,6 +28,7 @@
 "PreferenceViewController_setupViews_1553049563_16" = "CPU\n usage";
 "PreferenceViewController_setupViews_1553049563_17" = "GPU\n usage";
 "PreferenceViewController_setupViews_bootMonitorTitle _16" = "Show icons on menu bar on startup";
+"PreferenceViewController_toggleStatusBarVisibility" = "Show status bar icons";
 "About_windowAboutTitle_lemon" = "About Lemon Cleaner";
 "Appdelegate_about_windowAboutTitle_lemonlite" = "About Lemon Cleaner Lite";
 "AppDelegate_fetchResearchChannel_notification_1" = "Close";

--- a/Lemon/Resources/en.lproj/Localizable.strings
+++ b/Lemon/Resources/en.lproj/Localizable.strings
@@ -27,7 +27,7 @@
 "PreferenceViewController_setupViews_1553049563_15" = "Network\n speed";
 "PreferenceViewController_setupViews_1553049563_16" = "CPU\n usage";
 "PreferenceViewController_setupViews_1553049563_17" = "GPU\n usage";
-"PreferenceViewController_setupViews_bootMonitorTitle _16" = "Show icons on menu bar on startup";
+"PreferenceViewController_setupViews_bootMonitorTitle _16" = "Show on startup";
 "PreferenceViewController_toggleStatusBarVisibility" = "Show status bar icons";
 "About_windowAboutTitle_lemon" = "About Lemon Cleaner";
 "Appdelegate_about_windowAboutTitle_lemonlite" = "About Lemon Cleaner Lite";

--- a/Lemon/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Lemon/Resources/zh-Hans.lproj/Localizable.strings
@@ -27,7 +27,7 @@
 "PreferenceViewController_setupViews_1553049563_15" = "网速";
 "PreferenceViewController_setupViews_1553049563_16" = "CPU占用";
 "PreferenceViewController_setupViews_1553049563_17" = "GPU占用";
-"PreferenceViewController_setupViews_bootMonitorTitle _16" = "开机时显示状态栏图标";
+"PreferenceViewController_setupViews_bootMonitorTitle _16" = "开机时显示";
 "PreferenceViewController_toggleStatusBarVisibility" = "显示状态栏图标";
 "About_windowAboutTitle_lemon" = "关于腾讯柠檬清理";
 "Appdelegate_about_windowAboutTitle_lemonlite" = "关于Lemon Cleaner Lite";

--- a/Lemon/Resources/zh-Hans.lproj/Localizable.strings
+++ b/Lemon/Resources/zh-Hans.lproj/Localizable.strings
@@ -28,6 +28,7 @@
 "PreferenceViewController_setupViews_1553049563_16" = "CPU占用";
 "PreferenceViewController_setupViews_1553049563_17" = "GPU占用";
 "PreferenceViewController_setupViews_bootMonitorTitle _16" = "开机时显示状态栏图标";
+"PreferenceViewController_toggleStatusBarVisibility" = "显示状态栏图标";
 "About_windowAboutTitle_lemon" = "关于腾讯柠檬清理";
 "Appdelegate_about_windowAboutTitle_lemonlite" = "关于Lemon Cleaner Lite";
 "AppDelegate_fetchResearchChannel_notification_1" = "关闭";

--- a/Tools/LemonMonitor/LemonMonitor/Monitor/LMMonitorController.m
+++ b/Tools/LemonMonitor/LemonMonitor/Monitor/LMMonitorController.m
@@ -106,6 +106,13 @@ enum
 
 -(void)setupData
 {
+    NSNumber *type = [[NSUserDefaults standardUserDefaults] objectForKey:kLemonShowMonitorCfg];
+    if (([type integerValue] & STATUS_TYPE_GLOBAL) == 0) {
+        // 直接关闭进程（如果用户关闭了显示状态栏的开关）
+        [[NSApplication sharedApplication] terminate:nil];
+        return;
+    }
+    
     _upSpeedHistory = [[QMValueHistory alloc] initWithCapacity:32];
     _downSpeedHistory = [[QMValueHistory alloc] initWithCapacity:32];
     dataCenter = [QMDataCenter defaultCenter];

--- a/Tools/LemonMonitor/LemonMonitor/Monitor/LMMonitorController.m
+++ b/Tools/LemonMonitor/LemonMonitor/Monitor/LMMonitorController.m
@@ -618,6 +618,11 @@ enum
         NSInteger type = 0;
         NSDictionary* dict = notification.userInfo;
         type = ((NSNumber*)dict[@"type"]).integerValue;
+        if ((type & STATUS_TYPE_GLOBAL) == 0)
+        {
+            [[NSApplication sharedApplication] terminate:nil];
+            return;
+        }
         [statusView setStatusType:type];
         [[McStatMonitor shareMonitor] setTrayType:type];
 //        NSLog(@"receivedStatusChanged type=%lu", type);

--- a/localPod/QMUICommon/QMUICommon/Classes/COSwitch.m
+++ b/localPod/QMUICommon/QMUICommon/Classes/COSwitch.m
@@ -238,6 +238,9 @@
 
 - (void)mouseEntered:(NSEvent *)theEvent
 {
+    if (!self.isEnable) {
+        return;
+    }
     if (self.isAnimator) {
         [NSAnimationContext runAnimationGroup:^(NSAnimationContext *context) {
             context.duration = 0.1;


### PR DESCRIPTION
### Motivation

I don't want to have an icon in the MenuBar and I know I can quit LemonMonitor manually, but when the app re-launches, it will appear again, which, to me, is annoying

You know, new MacBook Pros has very limited space for menu bar.

### What's Changed 

I added a toggle to disable menu bar explicitly

### Demo

<img width="641" alt="截屏2024-11-25 21 59 40" src="https://github.com/user-attachments/assets/bc3946c1-5e15-4a7b-8e3a-6a61f7d4c0a7">

https://github.com/user-attachments/assets/2f0f7004-28ba-494a-9088-29f917d4a714

